### PR TITLE
Support for the Error groups in speccheck -- Extended open-rpc specs sample implementation

### DIFF
--- a/cmd/speccheck/extended_types.go
+++ b/cmd/speccheck/extended_types.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"encoding/json"
+
+	openrpc "github.com/open-rpc/meta-schema"
+)
+
+// ErrorObject represents a single error in an error group
+type ErrorObject struct {
+	Code    int         `json:"code"`
+	Message string      `json:"message"`
+	Data    interface{} `json:"data,omitempty"`
+}
+
+// ErrorGroup represents a group of errors
+type ErrorGroup []ErrorObject
+
+// ErrorGroups is an array of error groups
+type ErrorGroups []ErrorGroup
+
+// Add support for error group extensions in method objects
+type ExtendedMethodObject struct {
+	*openrpc.MethodObject
+	XErrorGroup ErrorGroups `json:"x-error-group,omitempty"`
+}
+
+// Wrap the standard MethodOrReference with extensions
+type ExtendedMethodOrReference struct {
+	MethodObject    *ExtendedMethodObject    `json:"-"`
+	ReferenceObject *openrpc.ReferenceObject `json:"-"`
+	Raw             map[string]interface{}   `json:"-"`
+}
+
+// Wraps the standard OpenrpcDocument with methods that support extensions
+type ExtendedOpenrpcDocument struct {
+	openrpc.OpenrpcDocument
+	Methods *[]ExtendedMethodOrReference `json:"methods"`
+}
+
+// UnmarshalJSON custom unmarshaller to capture both standard and extended fields
+func (e *ExtendedMethodOrReference) UnmarshalJSON(data []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	e.Raw = raw
+
+	// Check if it's a $ref object, should never be true
+	if _, ok := raw["$ref"]; ok {
+		refObj := &openrpc.ReferenceObject{}
+		if err := json.Unmarshal(data, refObj); err != nil {
+			return err
+		}
+		e.ReferenceObject = refObj
+		return nil
+	}
+
+	methodObj := &ExtendedMethodObject{
+		MethodObject: &openrpc.MethodObject{},
+	}
+	if err := json.Unmarshal(data, methodObj); err != nil {
+		return err
+	}
+	e.MethodObject = methodObj
+	return nil
+}

--- a/cmd/speccheck/spec.go
+++ b/cmd/speccheck/spec.go
@@ -17,9 +17,10 @@ type ContentDescriptor struct {
 // methodSchema stores all the schemas neccessary to validate a request or
 // response corresponding to the method.
 type methodSchema struct {
-	name   string
-	params []*ContentDescriptor
-	result *ContentDescriptor
+	name       string
+	params     []*ContentDescriptor
+	result     *ContentDescriptor
+	errorGroup ErrorGroups // Added error groups extension support
 }
 
 // parseSpec reads an OpenRPC specification and parses out each
@@ -79,6 +80,8 @@ func parseSpec(filename string) (map[string]*methodSchema, error) {
 			required: required,
 			schema:   *obj.Schema.JSONSchemaObject,
 		}
+
+		ms.errorGroup = method.XErrorGroup
 		parsed[string(*method.Name)] = &ms
 	}
 
@@ -125,12 +128,12 @@ func checkCDOR(obj openrpc.ContentDescriptorOrReference) error {
 	return nil
 }
 
-func readSpec(path string) (*openrpc.OpenrpcDocument, error) {
+func readSpec(path string) (*ExtendedOpenrpcDocument, error) {
 	spec, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
-	var doc openrpc.OpenrpcDocument
+	var doc ExtendedOpenrpcDocument
 	if err := json.Unmarshal(spec, &doc); err != nil {
 		return nil, err
 	}

--- a/cmd/speccheck/spec.go
+++ b/cmd/speccheck/spec.go
@@ -17,10 +17,10 @@ type ContentDescriptor struct {
 // methodSchema stores all the schemas neccessary to validate a request or
 // response corresponding to the method.
 type methodSchema struct {
-	name       string
-	params     []*ContentDescriptor
-	result     *ContentDescriptor
-	errorGroup ErrorGroups // Added error groups extension support
+	name        string
+	params      []*ContentDescriptor
+	result      *ContentDescriptor
+	errorGroups ErrorGroups // Added error groups extension support
 }
 
 // parseSpec reads an OpenRPC specification and parses out each
@@ -81,7 +81,7 @@ func parseSpec(filename string) (map[string]*methodSchema, error) {
 			schema:   *obj.Schema.JSONSchemaObject,
 		}
 
-		ms.errorGroup = method.XErrorGroup
+		ms.errorGroups = method.XErrorGroup
 		parsed[string(*method.Name)] = &ms
 	}
 


### PR DESCRIPTION

### Notes:
- Code can run the tests & print the error code mismatch
- Full error code lists need to be properly defined defined
- Test generators needs to be updated to generate more failure scenarios (esp. `eth_sendRawTransaction`)
https://github.com/simsonraj/rpctestgen/blob/error_groups_extension/testgen/generators.go 

### To Run:
- Generate the openrpc.json from execution-api https://github.com/simsonraj/execution-apis/tree/error_groups
- Copy-Paste the tests folder from above repo to the root of rpctestgen
- Run `go run github.com/lightclient/rpctestgen/cmd/speccheck -v`

### Result:
Currently only warns, but continues, need to update once the Proposal is ironed out
![image](https://github.com/user-attachments/assets/709579bb-2a91-4b64-a05a-04b9337ab4b1)
